### PR TITLE
Fix version option requiring an argument

### DIFF
--- a/wob.c
+++ b/wob.c
@@ -283,7 +283,7 @@ main(int argc, char **argv)
 	// Parse arguments
 	int c;
 	int timeout_msec = 1000;
-	while ((c = getopt(argc, argv, "t:v:h")) != -1) {
+	while ((c = getopt(argc, argv, "t:vh")) != -1) {
 		switch (c){
 			case 't':
 				timeout_msec = atoi(optarg);


### PR DESCRIPTION
It's a really simply fix and I didn't know if I should just fix it and open a PR or make an issue or both. Just removed the colon after the v in the `opstring` of `getopt` so it doesn't require an argument.