### PR TITLE
Fix a possible buffer overflow via user input from fgets

### DIFF
--- a/wob.c
+++ b/wob.c
@@ -10,6 +10,8 @@
 #define STRIDE WIDTH * 4
 #define SIZE STRIDE * HEIGHT
 
+#define INPUT_BUFFER_LENGTH 36
+
 #define _POSIX_C_SOURCE 200809L
 #ifndef DEBUG
 #define NDEBUG
@@ -420,7 +422,7 @@ main(int argc, char **argv)
 	bool hidden = true;
 	for (;;) {
 		uint16_t percentage = 0;
-		char input_buffer[36] = {0};
+		char input_buffer[INPUT_BUFFER_LENGTH] = {0};
 		char *fgets_rv;
 
 		switch (poll(fds, 2, hidden ? -1 : timeout_msec)) {
@@ -447,7 +449,7 @@ main(int argc, char **argv)
 					break;
 				}
 
-				fgets_rv = fgets(input_buffer, 37, stdin);
+				fgets_rv = fgets(input_buffer, INPUT_BUFFER_LENGTH, stdin);
 				if (feof(stdin)) {
 					wob_destroy(&app);
 					return EXIT_SUCCESS;


### PR DESCRIPTION
fgets reads at most n-1 characters but may need to store up to n
characters due to the final null-character.

The crash could e.g. be triggered with this command:
$ printf "000000000000000000000000000000000001" > "$SWAYSOCK.wob"

Which resulted in a buffer overflow:
$ tail -f "$SWAYSOCK.wob" | ./wob
*** buffer overflow detected ***: ./wob terminated
Aborted (core dumped)

---

I noticed this after compiling wob, which gave me the following warning:
```
[11/12] Compiling C object 'wob@exe/wob.c.o'.'.ble_v1_lib.a.generated_.._wlr-layer-shell-unstable-v1.c.o'.
In file included from /nix/store/zg3y0jq36pd8xf8rd8rhj8bcpinyrs3s-glibc-2.27-dev/include/stdio.h:862,
                 from ../wob.c:21:
In function 'fgets',
    inlined from 'main' at ../wob.c:450:16:
/nix/store/zg3y0jq36pd8xf8rd8rhj8bcpinyrs3s-glibc-2.27-dev/include/bits/stdio2.h:260:9: warning: call to '__fgets_chk_warn' declared with attribute warning: fgets called with bigger size than length of destination buffer
  return __fgets_chk_warn (__s, __bos (__s), __n, __stream);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[12/12] Linking target wob.
```

With this fix wob prints "Received invalid input" and exits (return code 1) without a buffer overflow.