### PR TITLE
Add man page in scdoc form

### DIFF
--- a/wob.1.scd
+++ b/wob.1.scd
@@ -1,0 +1,51 @@
+wob(1) ["Version 0.4"]
+
+# NAME
+
+wob - Wayland Overlay Bar
+
+# SYNOPSIS
+
+wob
+
+# DESCRIPTION 
+
+wob is a lightweight overlay volume/backlight/progress/anything bar for Wayland. This project is inspired by xob - X Overlay Bar.
+
+# USAGE
+
+Launch wob in a terminal, enter a value (positive integer), press return.
+	wob
+
+## General case
+
+You may manage a bar for audio volume, backlight intensity, or whatever, using a named pipe. Create a named pipe, e.g. /tmp/wobpipe, on your filesystem using.
+	mkfifo /tmp/wobpipe
+
+Connect the named pipe to the standard input of an wob instance.
+	tail -f /tmp/wobpipe | wob
+
+Set up your environment so that after updating audio volume, backlight intensity, or whatever, to a new value like 43, it writes that value into the pipe:
+	echo 43 > /tmp/wobpipe
+
+Adapt this use-case to your workflow (scripts, callbacks, or keybindings handled by the window manager).
+
+## Sway WM example
+	exec mkfifo $SWAYSOCK.wob && tail -f $SWAYSOCK.wob | wob
+
+Volume using alsa:
+	bindsym XF86AudioRaiseVolume exec amixer -q set Master 2%+ unmute && amixer sget Master | grep 'Right:' | awk -F'[][]' '{ print substr($2, 0, length($2)-1) }' > $SWAYSOCK.wob++
+bindsym XF86AudioLowerVolume exec amixer -q set Master 2%- unmute && amixer sget Master | grep 'Right:' | awk -F'[][]' '{ print substr($2, 0, length($2)-1) }' > $SWAYSOCK.wob++
+bindsym XF86AudioMute exec (amixer get Master | grep off > /dev/null && amixer -q set Master unmute && amixer sget Master | grep 'Right:' | awk -F'[][]' '{ print substr($2, 0, length($2)-1) }' > $SWAYSOCK.wob) || (amixer -q set Master mute && echo 0 > $SWAYSOCK.wob)
+
+Volume using pulse audio:
+	bindsym XF86AudioRaiseVolume exec pamixer -ui 2 && pamixer --get-volume > $SWAYSOCK.wob++
+bindsym XF86AudioLowerVolume exec pamixer -ud 2 && pamixer --get-volume > $SWAYSOCK.wob
+
+Brightness using [haikarainen/light](https://github.com/haikarainen/light):
+	bindsym XF86MonBrightnessUp exec light -A 5 && light -G | cut -d'.' -f1 > $SWAYSOCK.wob++
+bindsym XF86MonBrightnessDown exec light -U 5 && light -G | cut -d'.' -f1 > $SWAYSOCK.wob
+
+# LICENSE
+
+ISC.


### PR DESCRIPTION
Hello, I'm sure you remember my first PR (https://github.com/francma/wob/pull/1) for a man page, but it was in asciidoc format. In the time since you mentioned scdoc, I've rewritten the man page for my own project in scdoc and have just found some time to come back :)

I'm not sure how much reading you've done on scdoc, but the man page can be compiled with `scdoc < wob.1.scd > wob.1`. Then `man -l wob.1` to view. 

As for the content it was pretty much a copy+paste of the readme, with formatting changes for scdoc instead of markdown. Please let me know of any changes you would like to be made or feel free to make them yourself. 