### PR TITLE
Rename -Dman-page to -Dman-pages for consistency with other projects

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -82,7 +82,7 @@ test('parse-input', executable(
   include_directories: [wob_inc]
 ))
 
-scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: get_option('man-page'))
+scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: get_option('man-pages'))
 if scdoc.found()
   scdoc = find_program(scdoc.get_pkgconfig_variable('scdoc'), native: true)
   sh = find_program('sh', native: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,2 @@
-option('man-page', type: 'feature', value: 'auto', description: 'Generate and install man page')
+option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('seccomp', type: 'feature', value: 'auto', description: 'Use seccomp on Linux')


### PR DESCRIPTION
When creating FreeBSD packages I often use the following stanza. Consistency improves maintenance but whether option name is singular or plural is easy to miss. According [Repology](https://repology.org/project/wob/versions) Gentoo hasn't packaged this project yet, so only FreeBSD currently uses `-Dman-page`.
```bsdmake
OPTIONS_DEFINE=	MANPAGES
OPTIONS_DEFAULT=MANPAGES

MANPAGES_BUILD_DEPENDS=	scdoc:textproc/scdoc
MANPAGES_MESON_ENABLED=	man-pages
MANPAGES_PLIST_FILES=	man/man1/${PORTNAME}.1.gz
```