### PR TITLE
Allow newfsatat system call (fixes #62)

### DIFF
--- a/pledge_seccomp.c
+++ b/pledge_seccomp.c
@@ -22,6 +22,9 @@ wob_pledge(void)
 		SCMP_SYS(exit_group),
 		SCMP_SYS(fcntl),
 		SCMP_SYS(fstat),
+#if (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ > 32)) && defined(__NR_newfstatat)
+		SCMP_SYS(newfstatat),
+#endif
 		SCMP_SYS(gettimeofday),
 		SCMP_SYS(poll),
 		SCMP_SYS(ppoll),


### PR DESCRIPTION
In, glibc 2.33 fgets() call the fstatat64() wrapper function, which in
turn calls the newfstatat system call. This causes a SIGSYS signal due
to our Seccomp filter, unless we allow the system call.