### PR TITLE
Add wlroots (wlr_layer_shell_unstable_v1) notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![preview](https://martinfranc.eu/wob-preview.svg)
 
-A lightweight overlay volume/backlight/progress/anything bar for Wayland. This project is inspired by [xob - X Overlay Bar](https://github.com/florentc/xob).
+A lightweight overlay volume/backlight/progress/anything bar for wlroots based Wayland compositors (requrires support for `wlr_layer_shell_unstable_v1`). This project is inspired by [xob - X Overlay Bar](https://github.com/florentc/xob).
 
 ## Release signatures
 


### PR DESCRIPTION
Wob errors out on a GNOME Wayland session, so it's not compatible with every Wayland compositor. The notice should clear up the compatibility situation.