### PR TITLE
add parse_config_from_environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ Launch wob in a terminal, enter a value (positive integer), press return.
 wob
 ```
 
+### Configuration
+
+Configuration variables can be provided from the command line or as environment variables. For a list of options, see `wob --help`.
+For each command line options, the corresponding environment variable is prefixed by `WOB_` and has the same name converted to uppercase
+and with dashes replaced with underscores (e.g. `--bar-color` becomes `WOB_BAR_COLOR`).
+
+#### Logging:
+
+Have these variables set to anything to set logging level:
+
+- WOB_VERBOSE: set log level to INFO
+- WOB_DEBUG: set log level to DEBUG
+- WOB_ERROR: set log level to ERROR
+
 ### General case
 
 You may manage a bar for audio volume, backlight intensity, or whatever, using a named pipe. Create a named pipe, e.g. /tmp/wobpipe, on your filesystem using.
@@ -100,7 +114,32 @@ Brightness using [haikarainen/light](https://github.com/haikarainen/light):
 bindsym XF86MonBrightnessUp exec light -A 5 && light -G | cut -d'.' -f1 > $SWAYSOCK.wob
 bindsym XF86MonBrightnessDown exec light -U 5 && light -G | cut -d'.' -f1 > $SWAYSOCK.wob
 ```
+
 See the wiki for useful scripts.
+
+#### Sway+Systemd
+
+Copy the `.service` and `.socket` in `~/.local/share/systemd/user`:
+
+```
+cp systemd/wob.{service,socket} ~/.local/share/systemd/user/
+```
+
+add the following to your sway configuration:
+
+```
+set $WOBSOCK $XDG_RUNTIME_DIR/wob.sock
+```
+
+replace `$SWAYSOCK.wob` with `$WOBSOCK` in the above examples. Wob can be restarted with systemctl:
+
+```
+systemctl --user restart wob
+```
+
+Appeareance environment variables can be set in `$XDG_SESSION_HOME/wob.conf` (usually `~/.config/wob.conf`)
+
+Note that `wob` is automatically started whenever something is written to `$WOBSOCKET` due to the systemd socket unit `wob.socket`.
 
 ## License
 

--- a/config.c
+++ b/config.c
@@ -1,0 +1,132 @@
+#define WOB_FILE "config.c"
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "config.h"
+#include "log.h"
+#include "parse.h"
+#include <limits.h>
+
+#include "wlr-layer-shell-unstable-v1-client-protocol.h"
+#include "xdg-output-unstable-v1-client-protocol.h"
+
+bool
+wob_parse_geometry_from_environment(char *name, struct wob_geom *geom)
+{
+	char *strtoul_end;
+	char *env_string = getenv(name);
+
+	if (env_string == NULL) {
+		return false;
+	}
+
+	if (strcmp(name, "WOB_ANCHOR") == 0) {
+		if (!wob_parse_anchor(env_string, &(geom->anchor))) {
+			wob_log_error("Anchor must be one of 'top', 'bottom', 'left', 'right', 'center'.");
+			return false;
+		}
+		return true; // succesfully parsed anchor
+	}
+
+	unsigned long value = strtoul(env_string, &strtoul_end, 10);
+
+	if (*strtoul_end != '\0' || errno == ERANGE) {
+		wob_log_error("Got invalid value for %s from environment: %s)", name, env_string);
+		return false;
+	}
+
+	if (strcmp(name, "WOB_WIDTH") == 0) {
+		geom->width = value;
+	}
+	else if (strcmp(name, "WOB_HEIGHT") == 0) {
+		geom->height = value;
+	}
+	else if (strcmp(name, "WOB_BORDER_OFFSET") == 0) {
+		geom->border_offset = value;
+	}
+	else if (strcmp(name, "WOB_BORDER_SIZE") == 0) {
+		geom->border_size = value;
+	}
+	else if (strcmp(name, "WOB_BAR_PADDING") == 0) {
+		geom->bar_padding = value;
+	}
+	else if (strcmp(name, "WOB_STRIDE") == 0) {
+		geom->stride = value;
+	}
+	else if (strcmp(name, "WOB_SIZE") == 0) {
+		geom->size = value;
+	}
+	else if (strcmp(name, "WOB_MARGIN") == 0) {
+		geom->margin = value;
+	}
+	else {
+		wob_log_error("Invalid value: %s", name);
+		return false;
+	}
+	return true;
+};
+
+bool
+wob_parse_config_from_environment(struct wob_geom *geom, struct wob_colors *colors, unsigned long *timeout_msec)
+{
+	struct environment_config {
+		char *name;
+		unsigned long *value;
+	};
+	char *geom_config_names[] = {
+		"WOB_WIDTH",
+		"WOB_HEIGHT",
+		"WOB_BORDER_OFFSET",
+		"WOB_BORDER_SIZE",
+		"WOB_BAR_PADDING",
+		"WOB_STRIDE",
+		"WOB_SIZE",
+		"WOB_ANCHOR",
+		"WOB_MARGIN",
+	};
+	for (size_t i = 0; i < sizeof(geom_config_names) / sizeof(char *); ++i) {
+		char *name = geom_config_names[i];
+		if (wob_parse_geometry_from_environment(name, geom)) {
+			wob_log_info("Parsed %s from environment", name);
+		}
+	}
+
+	{
+		char *str_end;
+		struct wob_color parsed_color = {0};
+		char *env_str = getenv("WOB_BAR_COLOR");
+		if (env_str && wob_parse_color(env_str, &str_end, &parsed_color)) {
+			colors->bar = parsed_color;
+		}
+	}
+	{
+		char *str_end;
+		struct wob_color parsed_color = {0};
+		char *env_str = getenv("WOB_BORDER_COLOR");
+		if (env_str && wob_parse_color(env_str, &str_end, &parsed_color)) {
+			colors->border = parsed_color;
+		}
+	}
+	{
+		char *str_end;
+		struct wob_color parsed_color = {0};
+		char *env_str = getenv("WOB_BACKGROUND_COLOR");
+		if (env_str && wob_parse_color(env_str, &str_end, &parsed_color)) {
+			colors->background = parsed_color;
+		}
+	}
+
+	char *timeout_env = getenv("WOB_TIMEOUT");
+	if (timeout_env != NULL && strcmp(timeout_env, "0") != 0) {
+		char *strtoul_end;
+		unsigned long timeout_msec = strtoul(timeout_env, &strtoul_end, 10);
+		if (*strtoul_end != '\0' || errno == ERANGE || timeout_msec == 0) {
+			wob_log_error("Timeout must be a value between 1 and %lu.", ULONG_MAX);
+			return false;
+		}
+	}
+	return true;
+}

--- a/include/config.h
+++ b/include/config.h
@@ -1,0 +1,28 @@
+#ifndef _WOB_CONFIG_H
+#define _WOB_CONFIG_H
+
+#include <stdbool.h>
+
+#include "color.h"
+
+struct wob_geom {
+	unsigned long width;
+	unsigned long height;
+	unsigned long border_offset;
+	unsigned long border_size;
+	unsigned long bar_padding;
+	unsigned long stride;
+	unsigned long size;
+	unsigned long anchor;
+	unsigned long margin;
+};
+
+struct wob_colors {
+	struct wob_color bar;
+	struct wob_color background;
+	struct wob_color border;
+};
+
+bool wob_parse_config_from_environment(struct wob_geom *geom, struct wob_colors *colors, unsigned long *timeout_msec);
+
+#endif

--- a/include/log.h
+++ b/include/log.h
@@ -18,6 +18,8 @@ void wob_log_inc_verbosity(void);
 
 void wob_log_use_colors(bool use_colors);
 
+void wob_log_setup(void);
+
 #define wob_log_debug(...) _wob_log(_WOB_LOG_DEBUG, WOB_FILE, __LINE__, __VA_ARGS__)
 #define wob_log_info(...) _wob_log(_WOB_LOG_INFO, WOB_FILE, __LINE__, __VA_ARGS__)
 #define wob_log_warn(...) _wob_log(_WOB_LOG_WARN, WOB_FILE, __LINE__, __VA_ARGS__)

--- a/include/parse.h
+++ b/include/parse.h
@@ -9,4 +9,6 @@ bool wob_parse_color(const char *restrict str, char **restrict str_end, struct w
 
 bool wob_parse_input(const char *input_buffer, unsigned long *percentage, struct wob_color *background, struct wob_color *border, struct wob_color *bar);
 
+bool wob_parse_anchor(char *value, unsigned long *anchor);
+
 #endif

--- a/log.c
+++ b/log.c
@@ -111,3 +111,20 @@ wob_log_inc_verbosity(void)
 		wob_log_debug("Set log level to %s", verbosity_names[min_importance_to_log]);
 	}
 }
+
+void
+wob_log_setup(void)
+{
+	if (getenv("WOB_DEBUG") != NULL) {
+		wob_log_level_debug();
+	}
+	else if (getenv("WOB_VERBOSE") != NULL) {
+		wob_log_level_info();
+	}
+	else if (getenv("WOB_ERROR") != NULL) {
+		wob_log_level_error();
+	}
+	else { // default log level
+		wob_log_level_warn();
+	};
+}

--- a/main.c
+++ b/main.c
@@ -16,7 +16,7 @@
 #define STR(x) #x
 
 // sizeof already includes NULL byte
-#define INPUT_BUFFER_LENGTH (3 * sizeof(unsigned long) + sizeof(" #FF000000 #FFFFFFFF #FFFFFFFF\n"))
+#define INPUT_BUFFER_LENGTH (3 * sizeof(unsigned long) + sizeof(" #000000FF #FFFFFFFF #FFFFFFFF\n"))
 
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 
@@ -488,9 +488,9 @@ main(int argc, char **argv)
 		"  -M, --margin <px>          Define anchor margin in pixels, defaults to " STR(WOB_DEFAULT_MARGIN) ". \n"
 		"  -O, --output <name>        Define output to show bar on or '*' for all. If ommited, focused output is chosen.\n"
 		"                             May be specified multiple times.\n"
-		"  --border-color <#argb>     Define border color\n"
-		"  --background-color <#argb> Define background color\n"
-		"  --bar-color <#argb>        Define bar color\n"
+		"  --border-color <#rgba>     Define border color\n"
+		"  --background-color <#rgba> Define background color\n"
+		"  --bar-color <#rgba>        Define bar color\n"
 		"\n";
 
 	struct wob app = {0};

--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,7 @@ endforeach
 
 wob_inc = include_directories('include')
 
-wob_sources = ['main.c', 'parse.c', 'buffer.c', 'log.c', 'color.c']
+wob_sources = ['main.c', 'parse.c', 'buffer.c', 'log.c', 'color.c', 'config.c']
 wob_dependencies = [xdg_output_unstable_v1, wayland_client, wlr_layer_shell_unstable_v1, xdg_shell, rt]
 if seccomp.found()
   wob_dependencies += seccomp
@@ -79,7 +79,8 @@ executable(
 test('parse-input', executable(
   'test-parse-input',
   ['tests/wob_parse_input.c', 'parse.c', 'color.c'],
-  include_directories: [wob_inc]
+  include_directories: [wob_inc],
+  dependencies: wob_dependencies,
 ))
 
 scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: get_option('man-pages'))

--- a/parse.c
+++ b/parse.c
@@ -6,6 +6,10 @@
 #include <string.h>
 
 #include "parse.h"
+#include <limits.h>
+
+#include "wlr-layer-shell-unstable-v1-client-protocol.h"
+#include "xdg-output-unstable-v1-client-protocol.h"
 
 bool
 wob_parse_color(const char *restrict str, char **restrict str_end, struct wob_color *color)
@@ -80,4 +84,28 @@ wob_parse_input(const char *input_buffer, unsigned long *percentage, struct wob_
 	}
 
 	return input_ptr == newline_position;
+}
+
+bool
+wob_parse_anchor(char *value, unsigned long *anchor)
+{
+	if (strcmp(value, "left") == 0) {
+		*anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT;
+	}
+	else if (strcmp(value, "right") == 0) {
+		*anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT;
+	}
+	else if (strcmp(value, "top") == 0) {
+		*anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
+	}
+	else if (strcmp(value, "bottom") == 0) {
+		*anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;
+	}
+	else if (strcmp(value, "center") != 0) { // FIXME: remove last strcmp and just return false?
+		return false;
+	}
+	else {
+		return false;
+	}
+	return true;
 }

--- a/parse.c
+++ b/parse.c
@@ -32,10 +32,10 @@ wob_parse_color(const char *restrict str, char **restrict str_end, struct wob_co
 	}
 
 	*color = (struct wob_color){
-		.alpha = parts[0] / ((float) UINT8_MAX),
-		.red = parts[1] / ((float) UINT8_MAX),
-		.green = parts[2] / ((float) UINT8_MAX),
-		.blue = parts[3] / ((float) UINT8_MAX),
+		.red = parts[0] / ((float) UINT8_MAX),
+		.green = parts[1] / ((float) UINT8_MAX),
+		.blue = parts[2] / ((float) UINT8_MAX),
+		.alpha = parts[3] / ((float) UINT8_MAX),
 	};
 
 	if (str_end) {

--- a/systemd/wob.service
+++ b/systemd/wob.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=A lightweight overlay volume/backlight/progress/anything bar for Wayland
+Requires=wob.socket
+Wants=wob.socket
+Documentation=man:wob(1)
+Documentation=https://github.com/francma/wob/
+
+[Service]
+Type=simple
+StandardInput=socket
+StandardOutput=journal
+ExecStart=wob
+EnvironmentFile=%S/wob.conf
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+Also=wob.socket

--- a/systemd/wob.socket
+++ b/systemd/wob.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description=Socket for wob - A lightweight overlay volume/backlight/progress/anything bar for Wayland
+Before=wob.service
+
+[Socket]
+ListenFIFO=%t/wob.sock
+Service=wob.service
+SocketMode=0600
+
+[Install]
+WantedBy=sockets.target
+RequiredBy=wob.service

--- a/tests/wob_parse_input.c
+++ b/tests/wob_parse_input.c
@@ -15,14 +15,14 @@ main(int argc, char **argv)
 	bool result;
 
 	printf("running 1\n");
-	input = "25 #FF000000 #FFFFFFFF #FFFFFFFF\n";
+	input = "25 #000000FF #FFFFFFFF #FFFFFFFF\n";
 	result = wob_parse_input(input, &percentage, &background, &border, &bar);
 	if (!result || percentage != 25 || wob_color_to_argb(background) != 0xFF000000 || wob_color_to_argb(border) != 0xFFFFFFFF || wob_color_to_argb(bar) != 0xFFFFFFFF) {
 		return EXIT_FAILURE;
 	}
 
 	printf("running 2\n");
-	input = "25 #FF000000\n";
+	input = "25 #000000FF\n";
 	result = wob_parse_input(input, &percentage, &background, &border, &bar);
 	if (result) {
 		return EXIT_FAILURE;
@@ -36,7 +36,7 @@ main(int argc, char **argv)
 	}
 
 	printf("running 4\n");
-	input = "25 #FF000000 #FFFFFFFF #FFFFFFFF \n";
+	input = "25 #000000FF #FFFFFFFF #FFFFFFFF \n";
 	result = wob_parse_input(input, &percentage, &background, &border, &bar);
 	if (result) {
 		return EXIT_FAILURE;

--- a/wob.1.scd
+++ b/wob.1.scd
@@ -55,13 +55,13 @@ wob is a lightweight overlay volume/backlight/progress/anything bar for Wayland.
 	Define output to show bar on or '\*' for all. If ommited, focused output is chosen.
 	May be specified multiple times.
 
-*--border-color* <#AARRGGBB>
+*--border-color* <#RRGGBBAA>
 	Define border color, defaults to #FFFFFFFF.
 
-*--background-color* <#AARRGGBB>
-	Define background color, defaults to #FF000000.
+*--background-color* <#RRGGBBAA>
+	Define background color, defaults to #000000FF.
 
-*--bar-color* <#AARRGGBB>
+*--bar-color* <#RRGGBBAA>
 	Define bar color, defaults to #FFFFFFFF.
 
 # USAGE
@@ -74,7 +74,7 @@ or
 
 <value> <#background_color> <#border_color> <#bar_color>
 
-Where <value> is number in interval from 0 to *--max* and <#\*color> is color in #AARRGGBB format.
+Where <value> is number in interval from 0 to *--max* and <#\*color> is color in #RRGGBBAA format.
 
 # ENVIRONMENT
 


### PR DESCRIPTION
- add `wob_parse_config_from_environment`  to parse configuration values from environment variables
- add systemd units examples (`wob.service` reads configuration from environment from `~/.config/wob.conf`)
- use #RRGGBBAA syntax for colors instead of #AARRGGBBB (#70)

I guess this will also requires patching the `PKGBUILD` in the archlinux's community repos to install the systemd units