### PR TITLE
Allow munmap syscall

### DIFF
--- a/pledge_seccomp.c
+++ b/pledge_seccomp.c
@@ -22,6 +22,7 @@ wob_pledge(void)
 		SCMP_SYS(exit_group),
 		SCMP_SYS(fcntl),
 		SCMP_SYS(gettimeofday),
+		SCMP_SYS(munmap),
 		SCMP_SYS(poll),
 		SCMP_SYS(ppoll),
 		SCMP_SYS(read),


### PR DESCRIPTION
This cause crash on musl system
```
* thread #1, name = 'wob', stop reason = signal SIGSYS
  * frame #0: 0x00007f3626cd675c ld-musl-x86_64.so.1`__munmap [inlined] __syscall2(n=11, a1=139870555066368, a2=4096) at syscall_arch.h:21:2
    frame #1: 0x00007f3626cd674f ld-musl-x86_64.so.1`__munmap(start=0x00007f3626bfd000, len=4096) at munmap.c:10
    frame #2: 0x00007f3626c3649b libseccomp.so.2`___lldb_unnamed_symbol6$$libseccomp.so.2 + 379
    frame #3: 0x00007f3626c34ee8 libseccomp.so.2`seccomp_load + 40
    frame #4: 0x00005613e5e7d429 wob`wob_pledge at pledge_seccomp.c:52:13
    frame #5: 0x00005613e5e7b5ff wob`main(argc=1, argv=<unavailable>) at main.c:792:8
    frame #6: 0x00007f3626cb2589 ld-musl-x86_64.so.1`libc_start_main_stage2(main=(wob`main at main.c:484), argc=<unavailable>, argv=0x00007ffddce69698) at __libc_start_main.c:94:7
    frame #7: 0x00005613e5e79976 wob`_start + 22
```