### PR TITLE
fix: parse rgba correctly

### DIFF
--- a/color.c
+++ b/color.c
@@ -7,10 +7,10 @@
 uint32_t
 wob_color_to_argb(const struct wob_color color)
 {
-	uint8_t alpha = (uint8_t) color.a * UINT8_MAX;
-	uint8_t red = (uint8_t) color.r * UINT8_MAX;
-	uint8_t green = (uint8_t) color.g * UINT8_MAX;
-	uint8_t blue = (uint8_t) color.b * UINT8_MAX;
+	uint8_t alpha = (uint8_t) (color.a * UINT8_MAX);
+	uint8_t red = (uint8_t) (color.r * UINT8_MAX);
+	uint8_t green = (uint8_t) (color.g * UINT8_MAX);
+	uint8_t blue = (uint8_t) (color.b * UINT8_MAX);
 
 	return (alpha << 24) + (red << 16) + (green << 8) + blue;
 }

--- a/parse.c
+++ b/parse.c
@@ -27,10 +27,10 @@ wob_parse_color(const char *restrict str, char **restrict str_end, struct wob_co
 	}
 
 	*color = (struct wob_color){
-		.r = (float) parts[1] / UINT8_MAX,
-		.g = (float) parts[2] / UINT8_MAX,
-		.b = (float) parts[3] / UINT8_MAX,
-		.a = (float) parts[0] / UINT8_MAX,
+		.r = (float) parts[0] / UINT8_MAX,
+		.g = (float) parts[1] / UINT8_MAX,
+		.b = (float) parts[2] / UINT8_MAX,
+		.a = (float) parts[3] / UINT8_MAX,
 	};
 
 	if (str_end) {

--- a/tests/wob_parse_input.c
+++ b/tests/wob_parse_input.c
@@ -42,5 +42,15 @@ main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
+	printf("running 5\n");
+	input = "25 #000000FF #16a085FF #FF0000FF\n";
+	result = wob_parse_input(input, &percentage, &background, &border, &bar);
+	if (!result || percentage != 25 || wob_color_to_argb(background) != 0xFF000000 || wob_color_to_argb(border) != 0xFF16a085 || wob_color_to_argb(bar) != 0xFF0000FF) {
+		printf("background 0x%08x\n", wob_color_to_argb(background));
+		printf("border 0x%08x\n", wob_color_to_argb(border));
+		printf("bar 0x%08x\n", wob_color_to_argb(bar));
+		return EXIT_FAILURE;
+	}
+
 	return EXIT_SUCCESS;
 }

--- a/tests/wob_parse_input.c
+++ b/tests/wob_parse_input.c
@@ -45,10 +45,7 @@ main(int argc, char **argv)
 	printf("running 5\n");
 	input = "25 #000000FF #16a085FF #FF0000FF\n";
 	result = wob_parse_input(input, &percentage, &background, &border, &bar);
-	if (!result || percentage != 25 || wob_color_to_argb(background) != 0xFF000000 || wob_color_to_argb(border) != 0xFF16a085 || wob_color_to_argb(bar) != 0xFF0000FF) {
-		printf("background 0x%08x\n", wob_color_to_argb(background));
-		printf("border 0x%08x\n", wob_color_to_argb(border));
-		printf("bar 0x%08x\n", wob_color_to_argb(bar));
+	if (!result || percentage != 25 || wob_color_to_argb(background) != 0xFF000000 || wob_color_to_argb(border) != 0xFF16a085 || wob_color_to_argb(bar) != 0xFFFF0000) {
 		return EXIT_FAILURE;
 	}
 

--- a/tests/wob_parse_input.c
+++ b/tests/wob_parse_input.c
@@ -15,7 +15,7 @@ main(int argc, char **argv)
 	bool result;
 
 	printf("running 1\n");
-	input = "25 #FF000000 #FFFFFFFF #FFFFFFFF\n";
+	input = "25 #000000FF #FFFFFFFF #FFFFFFFF\n";
 	result = wob_parse_input(input, &percentage, &background, &border, &bar);
 	if (!result || percentage != 25 || wob_color_to_argb(background) != 0xFF000000 || wob_color_to_argb(border) != 0xFFFFFFFF || wob_color_to_argb(bar) != 0xFFFFFFFF) {
 		return EXIT_FAILURE;
@@ -36,7 +36,7 @@ main(int argc, char **argv)
 	}
 
 	printf("running 4\n");
-	input = "25 #FF000000 #FFFFFFFF #FFFFFFFF \n";
+	input = "25 #000000FF #FFFFFFFF #FFFFFFFF \n";
 	result = wob_parse_input(input, &percentage, &background, &border, &bar);
 	if (result) {
 		return EXIT_FAILURE;


### PR DESCRIPTION
apparently I did not test this properly and introduced an error parsing the rgba value while cherry-picking