### PR TITLE
Add ignore-invalid option

### DIFF
--- a/main.c
+++ b/main.c
@@ -499,6 +499,7 @@ main(int argc, char **argv)
 		"  -h, --help                          Show help message and quit.\n"
 		"  --version                           Show the version number and quit.\n"
 		"  -v                                  Increase verbosity of messages, defaults to errors and warnings only\n"
+		"  -i, --ignore-invalid                Ignore and skip invalid input\n"
 		"  -t, --timeout <ms>                  Hide wob after <ms> milliseconds, defaults to " STR(WOB_DEFAULT_TIMEOUT) ".\n"
 		"  -m, --max <%>                       Define the maximum percentage, defaults to " STR(WOB_DEFAULT_MAXIMUM) ". \n"
 		"  -W, --width <px>                    Define bar width in pixels, defaults to " STR(WOB_DEFAULT_WIDTH) ". \n"
@@ -522,6 +523,8 @@ main(int argc, char **argv)
 
 	struct wob app = {0};
 	wl_list_init(&(app.output_configs));
+
+	bool ignore_invalid = false;
 
 	unsigned long maximum = WOB_DEFAULT_MAXIMUM;
 	unsigned long timeout_msec = WOB_DEFAULT_TIMEOUT;
@@ -561,6 +564,7 @@ main(int argc, char **argv)
 		{"help", no_argument, NULL, 'h'},
 		{"version", no_argument, NULL, 4},
 		{"verbose", no_argument, NULL, 'v'},
+		{"ignore-invalid", no_argument, NULL, 'i'},
 		{"timeout", required_argument, NULL, 't'},
 		{"max", required_argument, NULL, 'm'},
 		{"width", required_argument, NULL, 'W'},
@@ -579,7 +583,7 @@ main(int argc, char **argv)
 		{"overflow-background-color", required_argument, NULL, 7},
 		{"overflow-border-color", required_argument, NULL, 8}};
 
-	while ((c = getopt_long(argc, argv, "hvt:m:W:H:o:b:p:a:M:O:", long_options, &option_index)) != -1) {
+	while ((c = getopt_long(argc, argv, "hvit:m:W:H:o:b:p:a:M:O:", long_options, &option_index)) != -1) {
 		switch (c) {
 			case 1:
 				if (!wob_parse_color(optarg, &strtoul_end, &(colors.border))) {
@@ -697,6 +701,9 @@ main(int argc, char **argv)
 				return EXIT_SUCCESS;
 			case 'v':
 				wob_log_inc_verbosity();
+				break;
+			case 'i':
+				ignore_invalid = true;
 				break;
 			case 5:
 				if (!wob_parse_color(optarg, &strtoul_end, &(overflow_colors.bar))) {
@@ -849,6 +856,9 @@ main(int argc, char **argv)
 
 					if (!wob_parse_input(input_buffer, &percentage, &colors.background, &colors.border, &colors.bar)) {
 						wob_log_error("Received invalid input");
+
+						if (ignore_invalid) break;
+
 						if (!hidden) wob_hide(&app);
 						wob_destroy(&app);
 

--- a/main.c
+++ b/main.c
@@ -560,6 +560,7 @@ main(int argc, char **argv)
 	static struct option long_options[] = {
 		{"help", no_argument, NULL, 'h'},
 		{"version", no_argument, NULL, 4},
+		{"verbose", no_argument, NULL, 'v'},
 		{"timeout", required_argument, NULL, 't'},
 		{"max", required_argument, NULL, 'm'},
 		{"width", required_argument, NULL, 'W'},
@@ -573,13 +574,12 @@ main(int argc, char **argv)
 		{"border-color", required_argument, NULL, 1},
 		{"background-color", required_argument, NULL, 2},
 		{"bar-color", required_argument, NULL, 3},
-		{"verbose", no_argument, NULL, 'v'},
 		{"overflow-mode", required_argument, NULL, 6},
 		{"overflow-bar-color", required_argument, NULL, 5},
 		{"overflow-background-color", required_argument, NULL, 7},
 		{"overflow-border-color", required_argument, NULL, 8}};
 
-	while ((c = getopt_long(argc, argv, "t:m:W:H:o:b:p:a:M:O:vh:f", long_options, &option_index)) != -1) {
+	while ((c = getopt_long(argc, argv, "hvt:m:W:H:o:b:p:a:M:O:", long_options, &option_index)) != -1) {
 		switch (c) {
 			case 1:
 				if (!wob_parse_color(optarg, &strtoul_end, &(colors.border))) {

--- a/wob.1.scd
+++ b/wob.1.scd
@@ -23,7 +23,7 @@ wob is a lightweight overlay volume/backlight/progress/anything bar for Wayland.
 *-v*
 	Increase verbosity of messages, defaults to errors and warnings only.
 
-*-t --timeout* <ms> 
+*-t --timeout* <ms>
 	Hide wob after <ms> milliseconds, defaults to 1000.
 
 *-m --max* <%>
@@ -74,7 +74,7 @@ wob is a lightweight overlay volume/backlight/progress/anything bar for Wayland.
 	Define overflow background color, defaults to #FF000000
 
 *--overflow-border-color* <#AARRGGBB>
-	Define overflow border color, defaults to #FFFFFFFF	
+	Define overflow border color, defaults to #FFFFFFFF
 
 # USAGE
 

--- a/wob.1.scd
+++ b/wob.1.scd
@@ -23,6 +23,9 @@ wob is a lightweight overlay volume/backlight/progress/anything bar for Wayland.
 *-v*
 	Increase verbosity of messages, defaults to errors and warnings only.
 
+*--i --ignore-invalid
+	Ignore and skip invalid input, defaults to quitting with exit code 1.
+
 *-t --timeout* <ms>
 	Hide wob after <ms> milliseconds, defaults to 1000.
 


### PR DESCRIPTION
```
By default wob exits when invalid input is read from stdin. Some users
might not want wob to exit here. This adds a runtime option that
controls wether wob will exit or just skip the input and wait for the
next input instead.
```

This PR adds a new runtime option (`-i` or `--ignore-invalid`) to just continue as usual if invalid input is sent.

This could be useful in case some script misbehaves, as the user will still get future feedback and can continue their work.