### PR TITLE
Delete the socket when sway starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Add these lines to your Sway config file:
 
 ```
 set $WOBSOCK $XDG_RUNTIME_DIR/wob.sock
-exec mkfifo $WOBSOCK && tail -f $WOBSOCK | wob
+exec rm -f $WOBSOCK && mkfifo $WOBSOCK && tail -f $WOBSOCK | wob
 ```
 
 Volume using alsa:


### PR DESCRIPTION
mkfifo will fail if the socket exists already. As a result, wob will not run, the socket will clog up and all the processes writing to it will accumulate. Delete the socket before recreating it to ensure a clean state.