### PR TITLE
Fix sway example for mute toggle in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Volume using pulse audio:
 ```
 bindsym XF86AudioRaiseVolume exec pamixer -ui 2 && pamixer --get-volume > $WOBSOCK
 bindsym XF86AudioLowerVolume exec pamixer -ud 2 && pamixer --get-volume > $WOBSOCK
-bindsym XF86AudioMute exec pamixer --toggle-mute && ( pamixer --get-mute && echo 0 > $WOBSOCK ) || pamixer --get-volume > $WOBSOCK
+bindsym XF86AudioMute exec pamixer --toggle-mute && ( [ "$(pamixer --get-mute)" = "true" ] && echo 0 > $WOBSOCK ) || pamixer --get-volume > $WOBSOCK
 ```
 
 Volume using pulse audio (altenative with pactl) :


### PR DESCRIPTION
Original `README.md` example for mute toggle would always write `0` to `$WOBSOCK`, whether you mute or unmute because `pamixer --get-mute` either prints to stdout `true` or `false`. This pull request address this issue so that the example correctly reports the actual volume when unmuting.