### PR TITLE
Allow mprotect syscall for hardened malloc

### DIFF
--- a/pledge_seccomp.c
+++ b/pledge_seccomp.c
@@ -24,6 +24,7 @@ wob_pledge(void)
 		SCMP_SYS(gettimeofday),
 		SCMP_SYS(_llseek),
 		SCMP_SYS(lseek),
+		SCMP_SYS(mprotect),
 		SCMP_SYS(munmap),
 		SCMP_SYS(poll),
 		SCMP_SYS(ppoll),


### PR DESCRIPTION
wob if built against or dynamically linked to [hardened malloc](https://github.com/GrapheneOS/hardened_malloc) will crash after receiving after a couple of inputs
GDB backtrace:
`Program terminated with signal SIGSYS, Bad system call.`
`#0  0x00006e643297a7bb in __GI_mprotect () at ../sysdeps/unix/syscall-template.S:117`