### PR TITLE
Respect Meson --mandir again

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -102,7 +102,7 @@ if scdoc.found()
         sh, '-c', '@0@ < @INPUT@ > @1@'.format(scdoc.path(), manfile)
       ],
       install: true,
-      install_dir: 'man@1@'.format(mandir, section)
+      install_dir: join_paths(mandir, 'man@0@'.format(section))
     )
   endforeach
 endif

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wob',
   'c',
-  version: '0.13',
+  version: '0.14',
   license: 'ISC',
   default_options: ['c_std=c99']
 )


### PR DESCRIPTION
Regressed by #78. `--mandir` defaults to `share/man` relative to `--prefix`. See also [Linux hier(7)](https://www.man7.org/linux/man-pages/man7/hier.7.html) and [FreeBSD hier(7)](https://man.freebsd.org/hier/7).

```
$ meson setup --prefix=/tmp/wob_prefix /tmp/wob_build
$ meson compile -C /tmp/wob_build
$ meson install -C /tmp/wob_build
[...]
Installing wob to /tmp/wob_prefix/bin
Installing wob.1 to /tmp/wob_prefix/man1
Installing wob.ini.5 to /tmp/wob_prefix/man5
```
