### PR TITLE
Prevent repeated crashes with socket activation

### DIFF
--- a/contrib/systemd/wob.socket
+++ b/contrib/systemd/wob.socket
@@ -1,6 +1,9 @@
 [Socket]
 ListenFIFO=%t/wob.sock
 SocketMode=0600
+RemoveOnStop=on
+# If wob exits on invalid input, systemd should NOT shove following input right back into it after it restarts
+FlushPending=yes
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
If an application shoves invalid input into the socket, the following input might be invalid as well.
systemd will, by default, send all pending input to the restarted process, in case the service crashed before.
We don't really want that, as it might cause wob to crash yet again. Therefore, systemd should just flush/discard all pending data and move on.