### PR TITLE
Add system config file under etc

### DIFF
--- a/config.c
+++ b/config.c
@@ -279,6 +279,7 @@ wob_config_default_path()
 	static const char *config_paths[] = {
 		"$XDG_CONFIG_HOME/wob/wob.ini",
 		"$HOME/.config/wob/wob.ini",
+		"/etc/wob/wob.ini",
 	};
 
 	for (size_t i = 0; i < sizeof(config_paths) / sizeof(char *); ++i) {

--- a/wob.1.scd
+++ b/wob.1.scd
@@ -44,6 +44,7 @@ wob searches for a config file in the following locations, in this order:
 
 1. $XDG_CONFIG_HOME/wob/wob.ini
 2. ~/.config/wob/wob.ini
+3. /etc/wob/wob.ini
 
 For information on the config file format, see *wob.ini*(5).
 


### PR DESCRIPTION
Hi, as we're packaging wob on [openSUSE](https://build.opensuse.org/package/show/X11:Wayland/wob) and using it in the [openSUSEway](https://en.opensuse.org/Portal:OpenSUSEway) environment, we would like to ship a default configuration file with our customizations. I propose adding it this way, since it would still allow the user to override it simply by adding their own `wob.ini` in their home directory.