### PR TITLE
Add contrib folder to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           prerelease: true
       - run: |
           mkdir "wob-${{ env.wob_tag }}"
-          mv src test protocols *.scd meson* LICENSE README.md "wob-${{ env.wob_tag }}"
+          mv src test contrib protocols *.scd meson* LICENSE README.md "wob-${{ env.wob_tag }}"
           tar -czf "wob-${{ env.wob_tag }}.tar.gz" "wob-${{ env.wob_tag }}"
       - uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
This should help distro maintainers who have been manually pulling and shipping the service files themselves.