### PR TITLE
FIX: Pipewire ex. not piped into `sed` resulting `Invalid value received 'Volume:'`

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -51,7 +51,7 @@ bindsym XF86AudioMute exec pactl set-sink-mute @DEFAULT_SINK@ toggle && ( [ "$(p
 ```
 wpctl set-volume @DEFAULT_AUDIO_SINK@ 2%+ && wpctl get-volume @DEFAULT_AUDIO_SINK@ | sed 's/[^0-9]//g' > $WOBSOCK
 wpctl set-volume @DEFAULT_AUDIO_SINK@ 2%- && wpctl get-volume @DEFAULT_AUDIO_SINK@ | sed 's/[^0-9]//g' > $WOBSOCK
-wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle && (wpctl get-volume @DEFAULT_AUDIO_SINK@ | grep -q MUTED && echo 0 > $WOBSOCK) || wpctl get-volume @DEFAULT_AUDIO_SINK@ > $WOBSOCK
+wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle && (wpctl get-volume @DEFAULT_AUDIO_SINK@ | grep -q MUTED && echo 0 > $WOBSOCK) || wpctl get-volume @DEFAULT_AUDIO_SINK@ | sed 's/[^0-9]//g' > $WOBSOCK
 ```
 
 ### Volume using Pipewire (alternative, if muted then block vol up/down and show 0):


### PR DESCRIPTION
In the example of using it with `PipeWrie`, the output was not piped into `sed` giving an output like `Volume: 0.33`. And causing `wob` to crash with this error:
```sh
1721898095.765212 ERROR wob.c:369: Invalid value received 'Volume:'
```

This PR fixes it