### PR TITLE
Set StandardOutput in service file

### DIFF
--- a/etc/systemd/wob.service.in
+++ b/etc/systemd/wob.service.in
@@ -7,6 +7,7 @@ ConditionEnvironment=WAYLAND_DISPLAY
 
 [Service]
 StandardInput=socket
+StandardOutput=journal
 ExecStart=@bindir@/wob
 
 [Install]


### PR DESCRIPTION
If StandardInput is "socket" StandardOutput defaults to "inherit" which is not what we want here ("inherit" causes stdout to be sent back into the FIFO).

Setting it to "journal" gives the behaviour most will want/expect.

Ideally this would be set to the value of DefaultStandardOutput (see man systemd-system.conf) but it doesn't look like there is an option for that.