### PR TITLE
Issue 96 coloured segments

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #define WOB_FILE "config.c"
 
 #define MIN_PERCENTAGE_BAR_WIDTH 1
@@ -199,7 +200,7 @@ int parse_segments(
             /* Parse: lower, upper, "hex" */
             int matched = sscanf(
                 p,
-                " %lf , %lf , \"%9[^\"]\"",
+                "%lf, %lf, %9[^\"]",
                 &lower,
                 &upper,
                 hex
@@ -225,8 +226,8 @@ int parse_segments(
                     }
                 }
 
-                bounds[count].lowerBound = lower;
-                bounds[count].upperBound = upper;
+                bounds[count].lowerBound = lower / 100;
+                bounds[count].upperBound = upper / 100;
 
                 unsigned int r, g, b, a;
 
@@ -239,7 +240,6 @@ int parse_segments(
                 colors[count].g = g / 255.0f;
                 colors[count].b = b / 255.0f;
                 colors[count].a = a / 255.0f;
-
                 count++;
             }
         }
@@ -382,8 +382,9 @@ handler(void *user, const char *section, const char *name, const char *value)
 		}
 		if (strcmp(name, "segments") == 0) {
             config->dimensions.segments.number = parse_segments(value,
-                                                                 &config->dimensions.segments.segmentArray,
-                                                                 &config->default_style.colors.segmentColours);
+                                                                 &(config->dimensions.segments.segmentArray),
+                                                                 &(config->default_style.colors.segmentColours));
+            return 1;
         }
 		if (strcmp(name, "output_mode") == 0) {
 			wob_log_warn("output_mode was removed, now it always behaves as \"focused\"");
@@ -802,6 +803,7 @@ wob_dimensions_apply_scale(struct wob_dimensions dimensions, uint32_t scale)
 		.bar_padding = scale_apply(dimensions.bar_padding, scale),
 		.border_offset = scale_apply(dimensions.border_offset, scale),
 		.border_size = scale_apply(dimensions.border_size, scale),
+        .segments = dimensions.segments,
 		.orientation = dimensions.orientation,
 	};
 

--- a/src/config.c
+++ b/src/config.c
@@ -167,6 +167,91 @@ parse_orientation(const char *str, enum wob_orientation *value)
 	return false;
 }
 
+int parse_segments(
+    const char *input,
+    struct wob_segment_bounds **boundsOut,
+    struct wob_color **colorsOut
+) {
+    int capacity = 8;
+    int count = 0;
+
+    struct wob_segment_bounds *bounds =
+        malloc(sizeof(struct wob_segment_bounds) * capacity);
+    struct wob_color *colors =
+        malloc(sizeof(struct wob_color) * capacity);
+
+    if (!bounds || !colors) {
+        free(bounds);
+        free(colors);
+        return -1;
+    }
+
+    const char *p = input;
+
+    while (*p) {
+        /* Find start of sublist */
+        if (*p == '[' && *(p + 1) != '[') {
+            p++;
+
+            double lower, upper;
+            char hex[10];
+
+            /* Parse: lower, upper, "hex" */
+            int matched = sscanf(
+                p,
+                " %lf , %lf , \"%9[^\"]\"",
+                &lower,
+                &upper,
+                hex
+            );
+
+            if (matched == 3) {
+                if (count >= capacity) {
+                    capacity *= 2;
+
+                    bounds = realloc(
+                        bounds,
+                        sizeof(struct wob_segment_bounds) * capacity
+                    );
+                    colors = realloc(
+                        colors,
+                        sizeof(struct wob_color) * capacity
+                    );
+
+                    if (!bounds || !colors) {
+                        free(bounds);
+                        free(colors);
+                        return -1;
+                    }
+                }
+
+                bounds[count].lowerBound = lower;
+                bounds[count].upperBound = upper;
+
+                unsigned int r, g, b, a;
+
+                if (hex[0] == '#')
+                    sscanf(hex + 1, "%2x%2x%2x%2x", &r, &g, &b, &a);
+                else
+                    sscanf(hex, "%2x%2x%2x%2x", &r, &g, &b, &a);
+
+                colors[count].r = r / 255.0f;
+                colors[count].g = g / 255.0f;
+                colors[count].b = b / 255.0f;
+                colors[count].a = a / 255.0f;
+
+                count++;
+            }
+        }
+
+        p++;
+    }
+
+    *boundsOut = bounds;
+    *colorsOut = colors;
+    return count;
+}
+
 int
 handler(void *user, const char *section, const char *name, const char *value)
 {
@@ -295,6 +380,11 @@ handler(void *user, const char *section, const char *name, const char *value)
 			}
 			return 1;
 		}
+		if (strcmp(name, "segments") == 0) {
+            config->dimensions.segments.number = parse_segments(value,
+                                                                 &config->dimensions.segments.segmentArray,
+                                                                 &config->default_style.colors.segmentColours);
+        }
 		if (strcmp(name, "output_mode") == 0) {
 			wob_log_warn("output_mode was removed, now it always behaves as \"focused\"");
 			return 0;

--- a/src/config.h
+++ b/src/config.h
@@ -2,6 +2,7 @@
 #define _WOB_CONFIG_H
 
 #include <stdbool.h>
+#include <string.h>
 #include <wayland-util.h>
 
 #include "color.h"
@@ -37,12 +38,23 @@ struct wob_margin {
 	unsigned long left;
 };
 
+struct wob_segment_bounds {
+    double lowerBound;
+    double upperBound;
+};
+
+struct wob_segments {
+    unsigned long number;
+    struct wob_segment_bounds* segmentArray;
+};
+
 struct wob_dimensions {
 	unsigned long width;
 	unsigned long height;
 	unsigned long border_offset;
 	unsigned long border_size;
 	unsigned long bar_padding;
+    struct wob_segments segments;
 	enum wob_orientation orientation;
 };
 
@@ -59,6 +71,7 @@ struct wob_colors {
 	struct wob_color background;
 	struct wob_color border;
 	struct wob_color value;
+    struct wob_color* segmentColours;
 };
 
 struct wob_style {

--- a/src/image.c
+++ b/src/image.c
@@ -30,8 +30,7 @@ void draw_segments(uint32_t* image_data, unsigned long width,
     unsigned long adjusted_width = width * percentage;
 
     for (int i = number_of_segments - 1; i >= 0; i--) {
-        if (adjusted_width >= width * segment_bounds[i].lowerBound) {
-            // printf("Colour: " WOB_COLOR_PRINTF_FORMAT "\n", WOB_COLOR_PRINTF_RGBA(unadjusted_segment_colours[i]));
+        if (adjusted_width >= width * segment_bounds[i].lowerBound && segment_bounds[i].lowerBound <= segment_bounds[i].upperBound) {
             if (adjusted_width > width * segment_bounds[i].upperBound) {
                 fill_rectangle(
                         image_data + (uint32_t)(width * segment_bounds[i].lowerBound),
@@ -109,7 +108,7 @@ wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wo
 
             if (number_of_segments > 0 && segment_colours != NULL) {
                 draw_segments(data,
-                              bar_width,
+                              bar_width + 1,
                               bar_height,
                               stride,
                               percentage,

--- a/src/image.c
+++ b/src/image.c
@@ -21,6 +21,40 @@ fill_rectangle(uint32_t *pixels, size_t width, size_t height, size_t stride, uin
 	}
 }
 
+void draw_segments_vertical(uint32_t* image_data, unsigned long actualWidth, unsigned long styledWidth,
+                   unsigned long height, unsigned long stride,
+                   double percentage, unsigned long number_of_segments,
+                   struct wob_segment_bounds* segment_bounds,
+                   uint32_t* segment_colours
+) {
+    unsigned long adjusted_height = height * percentage;
+
+    for (int i = number_of_segments - 1; i >= 0; i--) {
+        if (segment_bounds[i].lowerBound > segment_bounds[i].upperBound ||
+            adjusted_height < height * segment_bounds[i].lowerBound
+        ) {
+            continue;
+        }
+        if (adjusted_height > height * segment_bounds[i].upperBound) {
+            fill_rectangle(
+                            image_data + (int)((1 - segment_bounds[i].upperBound) * height) * actualWidth,
+                            styledWidth,
+                            height * (segment_bounds[i].upperBound - segment_bounds[i].lowerBound),
+                            stride, segment_colours[i]
+            );
+
+        }
+        else {
+            fill_rectangle(
+                            image_data + (int)((1 - percentage) * height) * actualWidth,
+                            styledWidth,
+                            height * (percentage - segment_bounds[i].lowerBound),
+                            stride, segment_colours[i]
+            );
+        }
+    }
+}
+
 void draw_segments(uint32_t* image_data, unsigned long width,
                    unsigned long height, unsigned long stride,
                    double percentage, unsigned long number_of_segments,
@@ -30,21 +64,25 @@ void draw_segments(uint32_t* image_data, unsigned long width,
     unsigned long adjusted_width = width * percentage;
 
     for (int i = number_of_segments - 1; i >= 0; i--) {
-        if (adjusted_width >= width * segment_bounds[i].lowerBound && segment_bounds[i].lowerBound <= segment_bounds[i].upperBound) {
-            if (adjusted_width > width * segment_bounds[i].upperBound) {
-                fill_rectangle(
-                        image_data + (uint32_t)(width * segment_bounds[i].lowerBound),
-                         (double)width * (segment_bounds[i].upperBound - segment_bounds[i].lowerBound),
-                                height, stride, segment_colours[i]
-                );
-            }
-            else {
-                fill_rectangle(
-                        image_data + (uint32_t)(width * segment_bounds[i].lowerBound),
-                         adjusted_width - width * segment_bounds[i].lowerBound,
-                                height, stride, segment_colours[i]
-                );
-            }
+        if (adjusted_width < width * segment_bounds[i].lowerBound ||
+            segment_bounds[i].lowerBound > segment_bounds[i].upperBound
+        ) {
+            continue;
+        }
+
+        if (adjusted_width > width * segment_bounds[i].upperBound) {
+            fill_rectangle(
+                    image_data + (uint32_t)(width * segment_bounds[i].lowerBound),
+                     (double)width * (segment_bounds[i].upperBound - segment_bounds[i].lowerBound),
+                            height, stride, segment_colours[i]
+            );
+        }
+        else {
+            fill_rectangle(
+                    image_data + (uint32_t)(width * segment_bounds[i].lowerBound),
+                     adjusted_width - width * segment_bounds[i].lowerBound,
+                            height, stride, segment_colours[i]
+            );
         }
     }
 }
@@ -108,7 +146,7 @@ wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wo
 
             if (number_of_segments > 0 && segment_colours != NULL) {
                 draw_segments(data,
-                              bar_width + 1,
+                              bar_width + 1, // fixes a weird bug where a single-pixel column of the original bar colour is visble at the end
                               bar_height,
                               stride,
                               percentage,
@@ -116,28 +154,31 @@ wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wo
                               segment_bounds,
                               segment_colours
                              );
-
             }
 
 			break;
 		case WOB_ORIENTATION_VERTICAL:
-                break;
-        // 	height = bar_height * percentage;
-		// 	width = bar_width;
-		// 	data = image_data + (offset * (dimensions.width + 1)) + (bar_height - height) * dimensions.width;
-
-            // for (int i = numberOfBounds - 1; i >= 0; i--) {
-                // if (width >= bar_height * test.segmentArray[i].lowerBound) {
-                    // if (width > bar_height * test.segmentArray[i].upperBound) {
-                        // fill_rectangle(data, width, (double)bar_height * test.segmentArray[i].upperBound, stride, segment_colours[i]);
-                    // }
-                    // else {
-                        // fill_rectangle(data, width, height, stride, segment_colours[i]);
-                    // }
-                // }
-            // }
-		// 	break;
+            height = bar_height * percentage;
+            width = bar_width;
+            data = image_data + (offset * (dimensions.width + 1));
+            
+            if (number_of_segments > 0 && segment_colours != NULL) {
+                fill_rectangle(
+                    data + (bar_height - height) * dimensions.width,
+                    width, height, stride, bar_color
+                );
+                
+                draw_segments_vertical(data,
+                              dimensions.width,
+                              bar_width,
+                              bar_height,
+                              stride,
+                              percentage,
+                              number_of_segments,
+                              segment_bounds,
+                              segment_colours
+                             );
+            }
+            break;
 	}
-
-    // free();
 }

--- a/src/image.c
+++ b/src/image.c
@@ -1,3 +1,9 @@
+#include "src/color.h"
+#include "src/config.h"
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #define WOB_FILE "image.c"
 
 #include "image.h"
@@ -14,11 +20,47 @@ fill_rectangle(uint32_t *pixels, size_t width, size_t height, size_t stride, uin
 }
 
 void
+populate_segment_array(unsigned long number, struct wob_segment_bounds arr[], struct wob_segments* segmentStruct) {
+    segmentStruct->number = number;
+    segmentStruct->segmentArray = calloc(number, sizeof(struct wob_segment_bounds));
+    if (segmentStruct->segmentArray == NULL) { return; }
+
+    for (unsigned long i = 0; i < number; i++) {
+        segmentStruct->segmentArray[i].lowerBound = arr[i].lowerBound / 100.0f;
+        segmentStruct->segmentArray[i].upperBound = arr[i].upperBound / 100.0f;
+    }
+}
+
+// void
+// populate_segment_colour_array(unsigned long number, struct wob_color* colourArray, )
+
+void
 wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wob_colors colors, double percentage)
 {
 	uint32_t bar_color = wob_color_to_argb(wob_color_premultiply_alpha(colors.value));
 	uint32_t background_color = wob_color_to_argb(wob_color_premultiply_alpha(colors.background));
 	uint32_t border_color = wob_color_to_argb(wob_color_premultiply_alpha(colors.border));
+    
+    struct wob_color colourArray[3] = {
+        {1, 0.7, 0.67, 0.3},
+        {1, 0.9, 0.9, 0.5},
+        {1, 0.7, 0.67, 0.9}
+    };
+    uint32_t segment_colours[3];
+
+    for (int i = 0; i < 3; i++) {
+        segment_colours[i] = wob_color_to_argb(wob_color_premultiply_alpha(colourArray[i]));
+    }
+
+    struct wob_segments test;
+    int numberOfBounds = 3;
+    struct wob_segment_bounds boundsArray[3] = {{0, 30}, {40, 67}, {70, 90}};
+    populate_segment_array(3, boundsArray, &test);
+
+    for (int i = 0; i < 3; i++) {
+        printf("%lf (%u), ", test.segmentArray[i].lowerBound, segment_colours[i]);
+    }
+    printf("\n");
 
 	uint32_t *data;
 	uint32_t height;
@@ -26,17 +68,20 @@ wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wo
 	uint32_t offset;
 	uint32_t stride = dimensions.width;
 
+    // draw background box
 	height = dimensions.height;
 	width = dimensions.width;
 	data = image_data;
 	fill_rectangle(data, width, height, stride, background_color);
 
+    // draw border as a box (will be drawn over to make it look like a border)
 	offset = dimensions.border_offset;
 	height = dimensions.height - (2 * offset);
 	width = dimensions.width - (2 * offset);
 	data = image_data + (offset * (dimensions.width + 1));
 	fill_rectangle(data, width, height, stride, border_color);
 
+    // fill the inner box
 	offset = dimensions.border_offset + dimensions.border_size;
 	height = dimensions.height - (2 * offset);
 	width = dimensions.width - (2 * offset);
@@ -51,13 +96,46 @@ wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wo
 			height = bar_height;
 			width = bar_width * percentage;
 			data = image_data + (offset * (dimensions.width + 1));
-			fill_rectangle(data, width, height, stride, bar_color);
+            
+            fill_rectangle(data, width, height, stride, bar_color);
+
+            for (int i = numberOfBounds - 1; i >= 0; i--) {
+                if (width >= bar_width * test.segmentArray[i].lowerBound) {
+                    if (width > bar_width * test.segmentArray[i].upperBound) {
+                        fill_rectangle(
+                                data + (uint32_t)(bar_width * test.segmentArray[i].lowerBound),
+                                 (double)bar_width * (test.segmentArray[i].upperBound - test.segmentArray[i].lowerBound),
+                                        height, stride, segment_colours[i]
+                        );
+                    }
+                    else {
+                        fill_rectangle(
+                                data + (uint32_t)(bar_width * test.segmentArray[i].lowerBound),
+                                 width - bar_width * test.segmentArray[i].lowerBound,
+                                        height, stride, segment_colours[i]
+                        );
+                    }
+                }
+            }
+
 			break;
 		case WOB_ORIENTATION_VERTICAL:
 			height = bar_height * percentage;
 			width = bar_width;
 			data = image_data + (offset * (dimensions.width + 1)) + (bar_height - height) * dimensions.width;
-			fill_rectangle(data, width, height, stride, bar_color);
+
+            for (int i = numberOfBounds - 1; i >= 0; i--) {
+                if (width >= bar_height * test.segmentArray[i].lowerBound) {
+                    if (width > bar_height * test.segmentArray[i].upperBound) {
+                        fill_rectangle(data, width, (double)bar_height * test.segmentArray[i].upperBound, stride, segment_colours[i]);
+                    }
+                    else {
+                        fill_rectangle(data, width, height, stride, segment_colours[i]);
+                    }
+                }
+            }
 			break;
 	}
+
+    free(test.segmentArray);
 }

--- a/src/image.c
+++ b/src/image.c
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <wayland-util.h>
 #define WOB_FILE "image.c"
 
 #include "image.h"
@@ -19,6 +21,35 @@ fill_rectangle(uint32_t *pixels, size_t width, size_t height, size_t stride, uin
 	}
 }
 
+void draw_segments(uint32_t* image_data, unsigned long width,
+                   unsigned long height, unsigned long stride,
+                   double percentage, unsigned long number_of_segments,
+                   struct wob_segment_bounds* segment_bounds,
+                   uint32_t* segment_colours
+) {
+    unsigned long adjusted_width = width * percentage;
+
+    for (int i = number_of_segments - 1; i >= 0; i--) {
+        if (adjusted_width >= width * segment_bounds[i].lowerBound) {
+            // printf("Colour: " WOB_COLOR_PRINTF_FORMAT "\n", WOB_COLOR_PRINTF_RGBA(unadjusted_segment_colours[i]));
+            if (adjusted_width > width * segment_bounds[i].upperBound) {
+                fill_rectangle(
+                        image_data + (uint32_t)(width * segment_bounds[i].lowerBound),
+                         (double)width * (segment_bounds[i].upperBound - segment_bounds[i].lowerBound),
+                                height, stride, segment_colours[i]
+                );
+            }
+            else {
+                fill_rectangle(
+                        image_data + (uint32_t)(width * segment_bounds[i].lowerBound),
+                         adjusted_width - width * segment_bounds[i].lowerBound,
+                                height, stride, segment_colours[i]
+                );
+            }
+        }
+    }
+}
+
 void
 wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wob_colors colors, double percentage)
 {
@@ -28,10 +59,13 @@ wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wo
     
     unsigned long number_of_segments = dimensions.segments.number;
     struct wob_color* unadjusted_segment_colours = colors.segmentColours;
-    uint32_t *segment_colours = calloc(dimensions.segments.number, sizeof(uint32_t));
+    uint32_t *segment_colours = NULL;
 
-    for (unsigned long i = 0; i < dimensions.segments.number; i++) {
-        segment_colours[i] = wob_color_to_argb(wob_color_premultiply_alpha(unadjusted_segment_colours[i]));
+    if (number_of_segments > 0 && unadjusted_segment_colours != NULL) {
+        segment_colours = calloc(dimensions.segments.number, sizeof(uint32_t));
+        for (unsigned long i = 0; i < dimensions.segments.number; i++) {
+            segment_colours[i] = wob_color_to_argb(wob_color_premultiply_alpha(unadjusted_segment_colours[i]));
+        }
     }
 
     struct wob_segment_bounds* segment_bounds = dimensions.segments.segmentArray;
@@ -73,28 +107,17 @@ wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wo
             
             fill_rectangle(data, width, height, stride, bar_color);
 
-            if (number_of_segments > 0) {
-            for (int i = number_of_segments - 1; i >= 0; i--) {
-                if (width >= bar_width * segment_bounds[i].lowerBound) {
-                    if (width > bar_width * segment_bounds[i].upperBound) {
-                        fill_rectangle(
-                                data + (uint32_t)(bar_width * segment_bounds[i].lowerBound),
-                                 (double)bar_width * (segment_bounds[i].upperBound - segment_bounds[i].lowerBound),
-                                        height, stride, segment_colours[i]
-                        );
-                    }
-                    else {
-                        fill_rectangle(
-                                data + (uint32_t)(bar_width * segment_bounds[i].lowerBound),
-                                 width - bar_width * segment_bounds[i].lowerBound,
-                                        height, stride, segment_colours[i]
-                        );
-                    }
-                }
-            }
-            }
-            else {
-                fill_rectangle(data, width, height, stride, bar_color);
+            if (number_of_segments > 0 && segment_colours != NULL) {
+                draw_segments(data,
+                              bar_width,
+                              bar_height,
+                              stride,
+                              percentage,
+                              number_of_segments,
+                              segment_bounds,
+                              segment_colours
+                             );
+
             }
 
 			break;

--- a/src/image.c
+++ b/src/image.c
@@ -136,6 +136,7 @@ wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wo
 	offset = dimensions.border_offset + dimensions.border_size + dimensions.bar_padding;
 	size_t bar_width = dimensions.width - 2 * offset;
 	size_t bar_height = dimensions.height - 2 * offset;
+
 	switch (dimensions.orientation) {
 		case WOB_ORIENTATION_HORIZONTAL:
 			height = bar_height;
@@ -161,13 +162,13 @@ wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wo
             height = bar_height * percentage;
             width = bar_width;
             data = image_data + (offset * (dimensions.width + 1));
+
+            fill_rectangle(
+                data + (bar_height - height) * dimensions.width,
+                width, height, stride, bar_color
+            );
             
             if (number_of_segments > 0 && segment_colours != NULL) {
-                fill_rectangle(
-                    data + (bar_height - height) * dimensions.width,
-                    width, height, stride, bar_color
-                );
-                
                 draw_segments_vertical(data,
                               dimensions.width,
                               bar_width,

--- a/src/image.c
+++ b/src/image.c
@@ -20,47 +20,21 @@ fill_rectangle(uint32_t *pixels, size_t width, size_t height, size_t stride, uin
 }
 
 void
-populate_segment_array(unsigned long number, struct wob_segment_bounds arr[], struct wob_segments* segmentStruct) {
-    segmentStruct->number = number;
-    segmentStruct->segmentArray = calloc(number, sizeof(struct wob_segment_bounds));
-    if (segmentStruct->segmentArray == NULL) { return; }
-
-    for (unsigned long i = 0; i < number; i++) {
-        segmentStruct->segmentArray[i].lowerBound = arr[i].lowerBound / 100.0f;
-        segmentStruct->segmentArray[i].upperBound = arr[i].upperBound / 100.0f;
-    }
-}
-
-// void
-// populate_segment_colour_array(unsigned long number, struct wob_color* colourArray, )
-
-void
 wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wob_colors colors, double percentage)
 {
 	uint32_t bar_color = wob_color_to_argb(wob_color_premultiply_alpha(colors.value));
 	uint32_t background_color = wob_color_to_argb(wob_color_premultiply_alpha(colors.background));
 	uint32_t border_color = wob_color_to_argb(wob_color_premultiply_alpha(colors.border));
     
-    struct wob_color colourArray[3] = {
-        {1, 0.7, 0.67, 0.3},
-        {1, 0.9, 0.9, 0.5},
-        {1, 0.7, 0.67, 0.9}
-    };
-    uint32_t segment_colours[3];
+    unsigned long number_of_segments = dimensions.segments.number;
+    struct wob_color* unadjusted_segment_colours = colors.segmentColours;
+    uint32_t *segment_colours = calloc(dimensions.segments.number, sizeof(uint32_t));
 
-    for (int i = 0; i < 3; i++) {
-        segment_colours[i] = wob_color_to_argb(wob_color_premultiply_alpha(colourArray[i]));
+    for (unsigned long i = 0; i < dimensions.segments.number; i++) {
+        segment_colours[i] = wob_color_to_argb(wob_color_premultiply_alpha(unadjusted_segment_colours[i]));
     }
 
-    struct wob_segments test;
-    int numberOfBounds = 3;
-    struct wob_segment_bounds boundsArray[3] = {{0, 30}, {40, 67}, {70, 90}};
-    populate_segment_array(3, boundsArray, &test);
-
-    for (int i = 0; i < 3; i++) {
-        printf("%lf (%u), ", test.segmentArray[i].lowerBound, segment_colours[i]);
-    }
-    printf("\n");
+    struct wob_segment_bounds* segment_bounds = dimensions.segments.segmentArray;
 
 	uint32_t *data;
 	uint32_t height;
@@ -99,43 +73,49 @@ wob_image_draw(uint32_t *image_data, struct wob_dimensions dimensions, struct wo
             
             fill_rectangle(data, width, height, stride, bar_color);
 
-            for (int i = numberOfBounds - 1; i >= 0; i--) {
-                if (width >= bar_width * test.segmentArray[i].lowerBound) {
-                    if (width > bar_width * test.segmentArray[i].upperBound) {
+            if (number_of_segments > 0) {
+            for (int i = number_of_segments - 1; i >= 0; i--) {
+                if (width >= bar_width * segment_bounds[i].lowerBound) {
+                    if (width > bar_width * segment_bounds[i].upperBound) {
                         fill_rectangle(
-                                data + (uint32_t)(bar_width * test.segmentArray[i].lowerBound),
-                                 (double)bar_width * (test.segmentArray[i].upperBound - test.segmentArray[i].lowerBound),
+                                data + (uint32_t)(bar_width * segment_bounds[i].lowerBound),
+                                 (double)bar_width * (segment_bounds[i].upperBound - segment_bounds[i].lowerBound),
                                         height, stride, segment_colours[i]
                         );
                     }
                     else {
                         fill_rectangle(
-                                data + (uint32_t)(bar_width * test.segmentArray[i].lowerBound),
-                                 width - bar_width * test.segmentArray[i].lowerBound,
+                                data + (uint32_t)(bar_width * segment_bounds[i].lowerBound),
+                                 width - bar_width * segment_bounds[i].lowerBound,
                                         height, stride, segment_colours[i]
                         );
                     }
                 }
+            }
+            }
+            else {
+                fill_rectangle(data, width, height, stride, bar_color);
             }
 
 			break;
 		case WOB_ORIENTATION_VERTICAL:
-			height = bar_height * percentage;
-			width = bar_width;
-			data = image_data + (offset * (dimensions.width + 1)) + (bar_height - height) * dimensions.width;
+                break;
+        // 	height = bar_height * percentage;
+		// 	width = bar_width;
+		// 	data = image_data + (offset * (dimensions.width + 1)) + (bar_height - height) * dimensions.width;
 
-            for (int i = numberOfBounds - 1; i >= 0; i--) {
-                if (width >= bar_height * test.segmentArray[i].lowerBound) {
-                    if (width > bar_height * test.segmentArray[i].upperBound) {
-                        fill_rectangle(data, width, (double)bar_height * test.segmentArray[i].upperBound, stride, segment_colours[i]);
-                    }
-                    else {
-                        fill_rectangle(data, width, height, stride, segment_colours[i]);
-                    }
-                }
-            }
-			break;
+            // for (int i = numberOfBounds - 1; i >= 0; i--) {
+                // if (width >= bar_height * test.segmentArray[i].lowerBound) {
+                    // if (width > bar_height * test.segmentArray[i].upperBound) {
+                        // fill_rectangle(data, width, (double)bar_height * test.segmentArray[i].upperBound, stride, segment_colours[i]);
+                    // }
+                    // else {
+                        // fill_rectangle(data, width, height, stride, segment_colours[i]);
+                    // }
+                // }
+            // }
+		// 	break;
 	}
 
-    free(test.segmentArray);
+    // free();
 }


### PR DESCRIPTION
Added support for segments as suggested by [jficz](https://github.com/jficz) in #96. Segments must be defined in the .ini file in the following format:

> segments = [lower bound, upper bound, #rrggbbaa], [lower bound, upper bound, #rrggbbaa] ...

E.g:

> segments = [0.0, 10.7, #92afffff], [15.5, 30.567, #ce97dbff], [50.0, 100.0, #567171ff]

Segments are rendered last to first, so they must be listed in ascending order according to their upper bounds, otherwise segments with smaller upper bounds will be hidden